### PR TITLE
fix: map maintenance status to critical in peering flattenChecks

### DIFF
--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -707,7 +707,7 @@ func flattenChecks(
 		for _, chk := range checks {
 			id := chk.CheckID
 			if id == api.NodeMaint || strings.HasPrefix(id, api.ServiceMaintPrefix) {
-				healthStatus = api.HealthMaint
+				healthStatus = api.HealthCritical
 				break // always wins
 			}
 			healthStatus = getMostImportantStatus(healthStatus, chk.Status)

--- a/agent/grpc-external/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager_test.go
@@ -921,7 +921,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthPassing,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"service_maintenance": {
 			checks: []*pbservice.HealthCheck{
@@ -930,7 +930,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthPassing,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"unknown": {
 			checks: []*pbservice.HealthCheck{
@@ -952,7 +952,7 @@ func TestFlattenChecks(t *testing.T) {
 					Status:  api.HealthCritical,
 				},
 			},
-			expect: api.HealthMaint,
+			expect: api.HealthCritical,
 		},
 		"critical_over_warning": {
 			checks: []*pbservice.HealthCheck{


### PR DESCRIPTION
## INFRA-14416: Maintenance instances not excluded from DNS on peered clusters

### Bug
In `flattenChecks` (`subscription_manager.go`), when a service is in maintenance mode, the health status was set to `api.HealthMaint`. However, the importing peer only filters `critical` status from DNS results. This means maintenance instances remained resolvable via DNS on peered clusters, defeating the purpose of maintenance mode.

### Fix
Change the `healthStatus` assignment from `api.HealthMaint` to `api.HealthCritical` in the maintenance detection block of `flattenChecks`. This ensures maintenance instances are correctly excluded from DNS on peered clusters.

### Changes
- `subscription_manager.go`: Map maintenance to critical instead of maint
- `subscription_manager_test.go`: Update test expectations accordingly

### Testing
All `TestFlattenChecks` subtests pass.