### PR TITLE
Cherry-pick INFRA-14028 peering race condition fix from 1.22-fix

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1408,7 +1408,7 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		require.NoError(t, s2.fsm.State().PeeringWrite(lastIdx, &pbpeering.PeeringWriteRequest{Peering: p2}))
 
 		// connect the stream
-		mst1, err := s2.peeringServer.Tracker.Connected(s2PeerID1)
+		mst1, _, err := s2.peeringServer.Tracker.Connected(s2PeerID1)
 		require.NoError(t, err)
 
 		// mimic tracking exported services
@@ -1419,7 +1419,7 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		})
 
 		// connect the stream
-		mst2, err := s2.peeringServer.Tracker.Connected(s2PeerID2)
+		mst2, _, err := s2.peeringServer.Tracker.Connected(s2PeerID2)
 		require.NoError(t, err)
 
 		// mimic tracking exported services

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -330,14 +330,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		With("peer_name", streamReq.PeerName).
 		With("peer_id", streamReq.LocalID).
 		With("dailer", !streamReq.IsAcceptor())
-	logger.Info("dio.test: realHandleStream started")
+	logger.Warn("dio.test: realHandleStream started")
 	logger.Trace("handling stream for peer")
 
 	// handleStreamCtx is local to this function.
 	handleStreamCtx, cancel := context.WithCancel(streamReq.Stream.Context())
 	defer cancel()
 
-	logger.Info("dio.test: registering stream with tracker")
+	logger.Warn("dio.test: registering stream with tracker")
 	status, gen, err := s.Tracker.Connected(streamReq.LocalID)
 	if err != nil {
 		logger.Error("dio.test: failed to register stream", "error", err)
@@ -346,11 +346,11 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		return 0, false, fmt.Errorf("failed to register stream: %v", err)
 	}
 	// From this point on, this stream is the connected stream for this peer.
-	logger.Info("dio.test: stream registered successfully")
+	logger.Warn("dio.test: stream registered successfully")
 
 	var trustDomain string
 	if s.ConnectEnabled {
-		logger.Info("dio.test: getting trust domain")
+		logger.Warn("dio.test: getting trust domain")
 		// Read the TrustDomain up front - we do not allow users to change the ClusterID
 		// so reading it once at the beginning of the stream is sufficient.
 		trustDomain, err = getTrustDomain(s.GetStore(), logger)
@@ -358,10 +358,10 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			logger.Error("dio.test: failed to get trust domain", "error", err)
 			return gen, true, err
 		}
-		logger.Info("dio.test: trust domain retrieved", "trustDomain", trustDomain)
+		logger.Warn("dio.test: trust domain retrieved", "trustDomain", trustDomain)
 	}
 
-	logger.Info("dio.test: creating subscription manager")
+	logger.Warn("dio.test: creating subscription manager")
 	remoteSubTracker := newResourceSubscriptionTracker()
 	mgr := newSubscriptionManager(
 		streamReq.Stream.Context(),
@@ -372,9 +372,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		s.GetStore,
 		remoteSubTracker,
 	)
-	logger.Info("dio.test: subscribing to updates")
+	logger.Warn("dio.test: subscribing to updates")
 	subCh := mgr.subscribe(streamReq.Stream.Context(), streamReq.LocalID, streamReq.PeerName, streamReq.Partition)
-	logger.Info("dio.test: subscription channel created")
+	logger.Warn("dio.test: subscription channel created")
 
 	// We need a mutex to protect against simultaneous sends to the client.
 	var sendMutex sync.Mutex
@@ -417,9 +417,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 	}
 
 	// Subscribe to all relevant resource types.
-	logger.Info("dio.test: subscribing to resource types", "count", len(resources))
+	logger.Warn("dio.test: subscribing to resource types", "count", len(resources))
 	for _, resourceURL := range resources {
-		logger.Info("dio.test: sending subscription request", "resourceURL", resourceURL)
+		logger.Warn("dio.test: sending subscription request", "resourceURL", resourceURL)
 		sub := makeReplicationRequest(&pbpeerstream.ReplicationMessage_Request{
 			ResourceURL: resourceURL,
 			PeerID:      streamReq.RemoteID,
@@ -429,9 +429,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			logger.Error("dio.test: failed to send subscription", "resourceURL", resourceURL, "error", err)
 			return gen, true, fmt.Errorf("failed to send subscription for %q to stream: %w", resourceURL, err)
 		}
-		logger.Info("dio.test: subscription sent successfully", "resourceURL", resourceURL)
+		logger.Warn("dio.test: subscription sent successfully", "resourceURL", resourceURL)
 	}
-	logger.Info("dio.test: all subscriptions sent, entering main loop")
+	logger.Warn("dio.test: all subscriptions sent, entering main loop")
 
 	// recvCh sends messages from the gRPC stream.
 	recvCh := make(chan *pbpeerstream.ReplicationMessage)
@@ -493,12 +493,12 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 	var nonce uint64
 
 	// The main loop that processes sends and receives.
-	logger.Info("dio.test: starting main loop")
+	logger.Warn("dio.test: starting main loop")
 	for {
 		select {
 		// When the doneCh is closed that means that the peering was deleted locally.
 		case <-status.Done():
-			logger.Info("dio.test: status.Done() received, ending stream")
+			logger.Warn("dio.test: status.Done() received, ending stream")
 			logger.Info("ending stream")
 
 			term := &pbpeerstream.ReplicationMessage{
@@ -544,7 +544,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			return gen, true, fmt.Errorf("heartbeat timeout")
 
 		case msg := <-recvCh:
-			logger.Info("dio.test: received message from peer")
+			logger.Warn("dio.test: received message from peer")
 			// NOTE: this code should have similar error handling to the
 			// initial handling code in StreamResources()
 
@@ -565,7 +565,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if req := msg.GetRequest(); req != nil {
-				logger.Info("dio.test: processing request message", "resourceURL", req.ResourceURL)
+				logger.Warn("dio.test: processing request message", "resourceURL", req.ResourceURL)
 				if !pbpeerstream.KnownTypeURL(req.ResourceURL) {
 					logger.Error("dio.test: unknown resource URL", "resourceURL", req.ResourceURL)
 					return gen, true, grpcstatus.Errorf(codes.InvalidArgument, "subscription request to unknown resource URL: %s", req.ResourceURL)
@@ -653,14 +653,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if resp := msg.GetResponse(); resp != nil {
-				logger.Info("dio.test: processing response message", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
+				logger.Warn("dio.test: processing response message", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, status, resp)
 				if err != nil {
 					logger.Error("dio.test: failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID, "error", err)
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackRecvError(err.Error())
 				} else {
-					logger.Info("dio.test: resource persisted successfully", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
+					logger.Warn("dio.test: resource persisted successfully", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackRecvResourceSuccess()
 				}
 
@@ -674,7 +674,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if term := msg.GetTerminated(); term != nil {
-				logger.Info("dio.test: received termination message from peer")
+				logger.Warn("dio.test: received termination message from peer")
 				logger.Info("peering was deleted by our peer: marking peering as terminated and cleaning up imported resources")
 
 				// Once marked as terminated, a separate deferred deletion routine will clean up imported resources.
@@ -682,7 +682,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 					logger.Error("dio.test: failed to mark peering as terminated", "error", err)
 					logger.Error("failed to mark peering as terminated: %w", err)
 				}
-				logger.Info("dio.test: peering marked as terminated, returning")
+				logger.Warn("dio.test: peering marked as terminated, returning")
 				return gen, true, nil
 			}
 
@@ -704,11 +704,11 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 		case update := <-subCh:
-			logger.Info("dio.test: received subscription update", "correlationID", update.CorrelationID)
+			logger.Warn("dio.test: received subscription update", "correlationID", update.CorrelationID)
 			var resp *pbpeerstream.ReplicationMessage_Response
 			switch {
 			case strings.HasPrefix(update.CorrelationID, subExportedServiceList):
-				logger.Info("dio.test: processing exported service list update")
+				logger.Warn("dio.test: processing exported service list update")
 				resp, err = makeExportedServiceListResponse(status, update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -717,7 +717,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 					continue
 				}
 			case strings.HasPrefix(update.CorrelationID, subExportedService):
-				logger.Info("dio.test: processing exported service update")
+				logger.Warn("dio.test: processing exported service update")
 				resp, err = makeServiceResponse(update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -727,7 +727,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				}
 
 			case update.CorrelationID == subCARoot:
-				logger.Info("dio.test: processing CA roots update")
+				logger.Warn("dio.test: processing CA roots update")
 				resp, err = makeCARootsResponse(update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -737,7 +737,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				}
 
 			case update.CorrelationID == subServerAddrs:
-				logger.Info("dio.test: processing server addresses update")
+				logger.Warn("dio.test: processing server addresses update")
 				resp, err = makeServerAddrsResponse(update)
 				if err != nil {
 					logger.Error("dio.test: failed to create server address response", "error", err)
@@ -751,7 +751,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				continue
 			}
 			if resp == nil {
-				logger.Info("dio.test: response is nil, skipping")
+				logger.Warn("dio.test: response is nil, skipping")
 				continue
 			}
 
@@ -759,14 +759,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			nonce++
 			resp.Nonce = fmt.Sprintf("%08x", nonce)
 
-			logger.Info("dio.test: sending replication response", "nonce", resp.Nonce, "correlationID", update.CorrelationID)
+			logger.Warn("dio.test: sending replication response", "nonce", resp.Nonce, "correlationID", update.CorrelationID)
 			replResp := makeReplicationResponse(resp)
 			if err := streamSend(replResp); err != nil {
 				// note: govet warns of context leak but it is cleaned up in a defer
 				logger.Error("dio.test: failed to push data", "correlationID", update.CorrelationID, "error", err)
 				return gen, true, fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
 			}
-			logger.Info("dio.test: replication response sent successfully", "correlationID", update.CorrelationID)
+			logger.Warn("dio.test: replication response sent successfully", "correlationID", update.CorrelationID)
 		}
 	}
 }

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -330,14 +330,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		With("peer_name", streamReq.PeerName).
 		With("peer_id", streamReq.LocalID).
 		With("dailer", !streamReq.IsAcceptor())
-	logger.Warn("dio.test: realHandleStream started")
+	logger.Debug("dio.test: realHandleStream started")
 	logger.Trace("handling stream for peer")
 
 	// handleStreamCtx is local to this function.
 	handleStreamCtx, cancel := context.WithCancel(streamReq.Stream.Context())
 	defer cancel()
 
-	logger.Warn("dio.test: registering stream with tracker")
+	logger.Debug("dio.test: registering stream with tracker")
 	status, gen, err := s.Tracker.Connected(streamReq.LocalID)
 	if err != nil {
 		logger.Error("dio.test: failed to register stream", "error", err)
@@ -346,11 +346,11 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		return 0, false, fmt.Errorf("failed to register stream: %v", err)
 	}
 	// From this point on, this stream is the connected stream for this peer.
-	logger.Warn("dio.test: stream registered successfully")
+	logger.Debug("dio.test: stream registered successfully")
 
 	var trustDomain string
 	if s.ConnectEnabled {
-		logger.Warn("dio.test: getting trust domain")
+		logger.Debug("dio.test: getting trust domain")
 		// Read the TrustDomain up front - we do not allow users to change the ClusterID
 		// so reading it once at the beginning of the stream is sufficient.
 		trustDomain, err = getTrustDomain(s.GetStore(), logger)
@@ -358,10 +358,10 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			logger.Error("dio.test: failed to get trust domain", "error", err)
 			return gen, true, err
 		}
-		logger.Warn("dio.test: trust domain retrieved", "trustDomain", trustDomain)
+		logger.Debug("dio.test: trust domain retrieved", "trustDomain", trustDomain)
 	}
 
-	logger.Warn("dio.test: creating subscription manager")
+	logger.Debug("dio.test: creating subscription manager")
 	remoteSubTracker := newResourceSubscriptionTracker()
 	mgr := newSubscriptionManager(
 		streamReq.Stream.Context(),
@@ -372,9 +372,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		s.GetStore,
 		remoteSubTracker,
 	)
-	logger.Warn("dio.test: subscribing to updates")
+	logger.Debug("dio.test: subscribing to updates")
 	subCh := mgr.subscribe(streamReq.Stream.Context(), streamReq.LocalID, streamReq.PeerName, streamReq.Partition)
-	logger.Warn("dio.test: subscription channel created")
+	logger.Debug("dio.test: subscription channel created")
 
 	// We need a mutex to protect against simultaneous sends to the client.
 	var sendMutex sync.Mutex
@@ -417,9 +417,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 	}
 
 	// Subscribe to all relevant resource types.
-	logger.Warn("dio.test: subscribing to resource types", "count", len(resources))
+	logger.Debug("dio.test: subscribing to resource types", "count", len(resources))
 	for _, resourceURL := range resources {
-		logger.Warn("dio.test: sending subscription request", "resourceURL", resourceURL)
+		logger.Debug("dio.test: sending subscription request", "resourceURL", resourceURL)
 		sub := makeReplicationRequest(&pbpeerstream.ReplicationMessage_Request{
 			ResourceURL: resourceURL,
 			PeerID:      streamReq.RemoteID,
@@ -429,9 +429,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			logger.Error("dio.test: failed to send subscription", "resourceURL", resourceURL, "error", err)
 			return gen, true, fmt.Errorf("failed to send subscription for %q to stream: %w", resourceURL, err)
 		}
-		logger.Warn("dio.test: subscription sent successfully", "resourceURL", resourceURL)
+		logger.Debug("dio.test: subscription sent successfully", "resourceURL", resourceURL)
 	}
-	logger.Warn("dio.test: all subscriptions sent, entering main loop")
+	logger.Debug("dio.test: all subscriptions sent, entering main loop")
 
 	// recvCh sends messages from the gRPC stream.
 	recvCh := make(chan *pbpeerstream.ReplicationMessage)
@@ -493,12 +493,12 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 	var nonce uint64
 
 	// The main loop that processes sends and receives.
-	logger.Warn("dio.test: starting main loop")
+	logger.Debug("dio.test: starting main loop")
 	for {
 		select {
 		// When the doneCh is closed that means that the peering was deleted locally.
 		case <-status.Done():
-			logger.Warn("dio.test: status.Done() received, ending stream")
+			logger.Debug("dio.test: status.Done() received, ending stream")
 			logger.Info("ending stream")
 
 			term := &pbpeerstream.ReplicationMessage{
@@ -544,7 +544,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			return gen, true, fmt.Errorf("heartbeat timeout")
 
 		case msg := <-recvCh:
-			logger.Warn("dio.test: received message from peer")
+			logger.Debug("dio.test: received message from peer")
 			// NOTE: this code should have similar error handling to the
 			// initial handling code in StreamResources()
 
@@ -565,7 +565,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if req := msg.GetRequest(); req != nil {
-				logger.Warn("dio.test: processing request message", "resourceURL", req.ResourceURL)
+				logger.Debug("dio.test: processing request message", "resourceURL", req.ResourceURL)
 				if !pbpeerstream.KnownTypeURL(req.ResourceURL) {
 					logger.Error("dio.test: unknown resource URL", "resourceURL", req.ResourceURL)
 					return gen, true, grpcstatus.Errorf(codes.InvalidArgument, "subscription request to unknown resource URL: %s", req.ResourceURL)
@@ -653,14 +653,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if resp := msg.GetResponse(); resp != nil {
-				logger.Warn("dio.test: processing response message", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
+				logger.Debug("dio.test: processing response message", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, status, resp)
 				if err != nil {
 					logger.Error("dio.test: failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID, "error", err)
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackRecvError(err.Error())
 				} else {
-					logger.Warn("dio.test: resource persisted successfully", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
+					logger.Debug("dio.test: resource persisted successfully", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackRecvResourceSuccess()
 				}
 
@@ -674,7 +674,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 			if term := msg.GetTerminated(); term != nil {
-				logger.Warn("dio.test: received termination message from peer")
+				logger.Debug("dio.test: received termination message from peer")
 				logger.Info("peering was deleted by our peer: marking peering as terminated and cleaning up imported resources")
 
 				// Once marked as terminated, a separate deferred deletion routine will clean up imported resources.
@@ -682,7 +682,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 					logger.Error("dio.test: failed to mark peering as terminated", "error", err)
 					logger.Error("failed to mark peering as terminated: %w", err)
 				}
-				logger.Warn("dio.test: peering marked as terminated, returning")
+				logger.Debug("dio.test: peering marked as terminated, returning")
 				return gen, true, nil
 			}
 
@@ -704,11 +704,11 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			}
 
 		case update := <-subCh:
-			logger.Warn("dio.test: received subscription update", "correlationID", update.CorrelationID)
+			logger.Debug("dio.test: received subscription update", "correlationID", update.CorrelationID)
 			var resp *pbpeerstream.ReplicationMessage_Response
 			switch {
 			case strings.HasPrefix(update.CorrelationID, subExportedServiceList):
-				logger.Warn("dio.test: processing exported service list update")
+				logger.Debug("dio.test: processing exported service list update")
 				resp, err = makeExportedServiceListResponse(status, update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -717,7 +717,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 					continue
 				}
 			case strings.HasPrefix(update.CorrelationID, subExportedService):
-				logger.Warn("dio.test: processing exported service update")
+				logger.Debug("dio.test: processing exported service update")
 				resp, err = makeServiceResponse(update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -727,7 +727,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				}
 
 			case update.CorrelationID == subCARoot:
-				logger.Warn("dio.test: processing CA roots update")
+				logger.Debug("dio.test: processing CA roots update")
 				resp, err = makeCARootsResponse(update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
@@ -737,7 +737,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				}
 
 			case update.CorrelationID == subServerAddrs:
-				logger.Warn("dio.test: processing server addresses update")
+				logger.Debug("dio.test: processing server addresses update")
 				resp, err = makeServerAddrsResponse(update)
 				if err != nil {
 					logger.Error("dio.test: failed to create server address response", "error", err)
@@ -746,12 +746,12 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 				}
 
 			default:
-				logger.Warn("dio.test: unrecognized update type from subscription manager: " + update.CorrelationID)
+				logger.Debug("dio.test: unrecognized update type from subscription manager: " + update.CorrelationID)
 				logger.Warn("unrecognized update type from subscription manager: " + update.CorrelationID)
 				continue
 			}
 			if resp == nil {
-				logger.Warn("dio.test: response is nil, skipping")
+				logger.Debug("dio.test: response is nil, skipping")
 				continue
 			}
 
@@ -759,14 +759,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 			nonce++
 			resp.Nonce = fmt.Sprintf("%08x", nonce)
 
-			logger.Warn("dio.test: sending replication response", "nonce", resp.Nonce, "correlationID", update.CorrelationID)
+			logger.Debug("dio.test: sending replication response", "nonce", resp.Nonce, "correlationID", update.CorrelationID)
 			replResp := makeReplicationResponse(resp)
 			if err := streamSend(replResp); err != nil {
 				// note: govet warns of context leak but it is cleaned up in a defer
 				logger.Error("dio.test: failed to push data", "correlationID", update.CorrelationID, "error", err)
 				return gen, true, fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
 			}
-			logger.Warn("dio.test: replication response sent successfully", "correlationID", update.CorrelationID)
+			logger.Debug("dio.test: replication response sent successfully", "correlationID", update.CorrelationID)
 		}
 	}
 }

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -302,19 +302,29 @@ func (s *Server) DrainStream(req HandleStreamRequest) {
 }
 
 func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
-	if err := s.realHandleStream(streamReq); err != nil {
-		s.Tracker.DisconnectedDueToError(streamReq.LocalID, err.Error())
+	gen, connected, err := s.realHandleStream(streamReq)
+	if err != nil {
+		// Only mark as disconnected if this stream was actually connected.
+		// If Connected() failed (e.g., because there's already an active stream
+		// for this peer), we should not corrupt the existing stream's status.
+		if connected {
+			s.Tracker.DisconnectedDueToError(streamReq.LocalID, gen, err.Error())
+		}
 		s.Logger.Error("dio.test: stream handler error new peer status", s.Tracker.StreamStatusString(streamReq.LocalID))
 		return err
 	}
 	// TODO(peering) Also need to clear subscriptions associated with the peer
-	s.Tracker.DisconnectedGracefully(streamReq.LocalID)
+	s.Tracker.DisconnectedGracefully(streamReq.LocalID, gen)
 	return nil
 }
 
 // The localID provided is the locally-generated identifier for the peering.
 // The remoteID is an identifier that the remote peer recognizes for the peering.
-func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
+// Returns (generation, connected, error) where generation is the stream generation counter
+// and connected indicates if this stream successfully registered as the active stream
+// for the peer. These are used by HandleStream to determine whether to mark the stream
+// as disconnected on error, and to prevent stale disconnects from corrupting newer streams.
+func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, error) {
 	// TODO: pass logger down from caller?
 	logger := s.Logger.Named("stream").
 		With("peer_name", streamReq.PeerName).
@@ -328,13 +338,14 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 	defer cancel()
 
 	logger.Info("dio.test: registering stream with tracker")
-	status, err := s.Tracker.Connected(streamReq.LocalID)
+	status, gen, err := s.Tracker.Connected(streamReq.LocalID)
 	if err != nil {
 		logger.Error("dio.test: failed to register stream", "error", err)
-		// Return a FailedPrecondition error so the dialer retries quickly (8ms intervals)
-		// This commonly happens during leader elections when the old stream hasn't been cleaned up yet
-		return fmt.Errorf("failed to register stream: %v", err)
+		// Return connected=false so HandleStream knows not to mark as disconnected.
+		// This prevents corrupting an existing active stream's status.
+		return 0, false, fmt.Errorf("failed to register stream: %v", err)
 	}
+	// From this point on, this stream is the connected stream for this peer.
 	logger.Info("dio.test: stream registered successfully")
 
 	var trustDomain string
@@ -345,7 +356,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 		trustDomain, err = getTrustDomain(s.GetStore(), logger)
 		if err != nil {
 			logger.Error("dio.test: failed to get trust domain", "error", err)
-			return err
+			return gen, true, err
 		}
 		logger.Info("dio.test: trust domain retrieved", "trustDomain", trustDomain)
 	}
@@ -416,7 +427,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 		if err := streamSend(sub); err != nil {
 			// TODO(peering) Test error handling in calls to Send/Recv
 			logger.Error("dio.test: failed to send subscription", "resourceURL", resourceURL, "error", err)
-			return fmt.Errorf("failed to send subscription for %q to stream: %w", resourceURL, err)
+			return gen, true, fmt.Errorf("failed to send subscription for %q to stream: %w", resourceURL, err)
 		}
 		logger.Info("dio.test: subscription sent successfully", "resourceURL", resourceURL)
 	}
@@ -499,13 +510,13 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				// Nolint directive needed due to bug in govet that doesn't see that the cancel
 				// func of the incomingHeartbeatTimer _does_ get called.
 				//nolint:govet
-				return fmt.Errorf("failed to send to stream: %v", err)
+				return gen, true, fmt.Errorf("failed to send to stream: %v", err)
 			}
 
 			logger.Trace("deleting stream status")
 			s.Tracker.DeleteStatus(streamReq.LocalID)
 
-			return nil
+			return gen, true, nil
 
 		// Handle errors received from the stream by shutting down our handler.
 		case err := <-recvErrCh:
@@ -525,12 +536,12 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				err = fmt.Errorf("unexpected error receiving from the stream: %w", err)
 			}
 			status.TrackRecvError(err.Error())
-			return err
+			return gen, true, err
 
 		// We haven't received a heartbeat within the expected interval. Kill the stream.
 		case <-incomingHeartbeatCtx.Done():
 			logger.Error("dio.test: heartbeat timeout detected")
-			return fmt.Errorf("heartbeat timeout")
+			return gen, true, fmt.Errorf("heartbeat timeout")
 
 		case msg := <-recvCh:
 			logger.Info("dio.test: received message from peer")
@@ -547,9 +558,9 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 					&pbpeerstream.LeaderAddress{Address: s.Backend.GetLeaderAddress()})
 				if err != nil {
 					logger.Error(fmt.Sprintf("failed to marshal the leader address in response; err: %v", err))
-					return grpcstatus.Error(codes.FailedPrecondition, "node is not a leader anymore; cannot continue streaming")
+					return gen, true, grpcstatus.Error(codes.FailedPrecondition, "node is not a leader anymore; cannot continue streaming")
 				} else {
-					return st.Err()
+					return gen, true, st.Err()
 				}
 			}
 
@@ -557,7 +568,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				logger.Info("dio.test: processing request message", "resourceURL", req.ResourceURL)
 				if !pbpeerstream.KnownTypeURL(req.ResourceURL) {
 					logger.Error("dio.test: unknown resource URL", "resourceURL", req.ResourceURL)
-					return grpcstatus.Errorf(codes.InvalidArgument, "subscription request to unknown resource URL: %s", req.ResourceURL)
+					return gen, true, grpcstatus.Errorf(codes.InvalidArgument, "subscription request to unknown resource URL: %s", req.ResourceURL)
 				}
 
 				// There are different formats of requests depending upon where in the stream lifecycle we are.
@@ -599,7 +610,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 						if req.PeerID != "" && req.PeerID != streamReq.RemoteID {
 							// Not necessary after the first request from the dialer,
 							// but if provided must match.
-							return grpcstatus.Errorf(codes.InvalidArgument,
+							return gen, true, grpcstatus.Errorf(codes.InvalidArgument,
 								"initial subscription requests for a resource type must have consistent PeerID values: got=%q expected=%q",
 								req.PeerID,
 								streamReq.RemoteID,
@@ -607,10 +618,10 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 						}
 					}
 					if req.ResponseNonce != "" {
-						return grpcstatus.Error(codes.InvalidArgument, "initial subscription requests for a resource type must not contain a nonce")
+						return gen, true, grpcstatus.Error(codes.InvalidArgument, "initial subscription requests for a resource type must not contain a nonce")
 					}
 					if req.Error != nil {
-						return grpcstatus.Error(codes.InvalidArgument, "initial subscription request for a resource type must not contain an error")
+						return gen, true, grpcstatus.Error(codes.InvalidArgument, "initial subscription request for a resource type must not contain an error")
 					}
 
 					if remoteSubTracker.Subscribe(req.ResourceURL) {
@@ -656,7 +667,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				// We are replying ACK or NACK depending on whether we successfully processed the response.
 				if err := streamSend(reply); err != nil {
 					logger.Error("dio.test: failed to send to stream", "reply", reply, "error", err)
-					return fmt.Errorf("failed to send to stream: %v", err)
+					return gen, true, fmt.Errorf("failed to send to stream: %v", err)
 				}
 
 				continue
@@ -672,7 +683,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 					logger.Error("failed to mark peering as terminated: %w", err)
 				}
 				logger.Info("dio.test: peering marked as terminated, returning")
-				return nil
+				return gen, true, nil
 			}
 
 			if msg.GetHeartbeat() != nil {
@@ -753,7 +764,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 			if err := streamSend(replResp); err != nil {
 				// note: govet warns of context leak but it is cleaned up in a defer
 				logger.Error("dio.test: failed to push data", "correlationID", update.CorrelationID, "error", err)
-				return fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
+				return gen, true, fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
 			}
 			logger.Info("dio.test: replication response sent successfully", "correlationID", update.CorrelationID)
 		}

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1590,7 +1590,7 @@ func Test_ExportedServicesCount(t *testing.T) {
 	}))
 
 	// connect the stream
-	mst, err := srv.Tracker.Connected(peerID)
+	mst, _, err := srv.Tracker.Connected(peerID)
 	require.NoError(t, err)
 
 	services := []string{
@@ -1633,7 +1633,7 @@ func Test_processResponse_Validation(t *testing.T) {
 	}))
 
 	// connect the stream
-	mst, err := srv.Tracker.Connected(peerID)
+	mst, _, err := srv.Tracker.Connected(peerID)
 	require.NoError(t, err)
 
 	run := func(t *testing.T, tc testCase) {
@@ -1969,7 +1969,7 @@ func processResponse_ExportedServiceUpdates(
 	}))
 
 	// connect the stream
-	mst, err := srv.Tracker.Connected(peerID)
+	mst, _, err := srv.Tracker.Connected(peerID)
 	require.NoError(t, err)
 
 	run := func(t *testing.T, tc PeeringProcessResponse_testCase) {

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -63,18 +63,20 @@ func (t *Tracker) registerLocked(id string, initAsConnected bool) (*MutableStatu
 
 // Connected registers a stream for a given peer, and marks it as connected.
 // It also enforces that there is only one active stream for a peer.
-func (t *Tracker) Connected(id string) (*MutableStatus, error) {
+// Returns the MutableStatus, the stream generation, and any error.
+func (t *Tracker) Connected(id string) (*MutableStatus, uint64, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.connectedLocked(id)
 }
 
-func (t *Tracker) connectedLocked(id string) (*MutableStatus, error) {
+func (t *Tracker) connectedLocked(id string) (*MutableStatus, uint64, error) {
 	status, newlyRegistered, err := t.registerLocked(id, true)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	} else if newlyRegistered {
-		return status, nil
+		// newMutableStatus with connected=true sets streamGeneration=1
+		return status, status.streamGeneration, nil
 	}
 
 	// Check if there's a truly active stream by seeing if the done channel is still open
@@ -86,31 +88,33 @@ func (t *Tracker) connectedLocked(id string) (*MutableStatus, error) {
 			// This prevents race condition where stream fails but Connected hasn't been updated yet
 		default:
 			// doneCh still open, stream is truly active
-			return nil, fmt.Errorf("there is an active stream for the given PeerID %q", id)
+			return nil, 0, fmt.Errorf("there is an active stream for the given PeerID %q", id)
 		}
 	}
-	status.TrackConnected()
+	gen := status.TrackConnected()
 
-	return status, nil
+	return status, gen, nil
 }
 
 // DisconnectedGracefully marks the peer id's stream status as disconnected gracefully.
-func (t *Tracker) DisconnectedGracefully(id string) {
+// The gen parameter ensures only the current stream generation can mark the peer as disconnected.
+func (t *Tracker) DisconnectedGracefully(id string, gen uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if status, ok := t.streams[id]; ok {
-		status.TrackDisconnectedGracefully()
+		status.TrackDisconnectedGracefullyIfCurrent(gen)
 	}
 }
 
 // DisconnectedDueToError marks the peer id's stream status as disconnected due to an error.
-func (t *Tracker) DisconnectedDueToError(id string, error string) {
+// The gen parameter ensures only the current stream generation can mark the peer as disconnected.
+func (t *Tracker) DisconnectedDueToError(id string, gen uint64, error string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if status, ok := t.streams[id]; ok {
-		status.TrackDisconnectedDueToError(error)
+		status.TrackDisconnectedDueToErrorIfCurrent(gen, error)
 	}
 }
 
@@ -223,6 +227,14 @@ func (t *Tracker) DeleteStatus(id string) {
 //
 // If none of these conditions apply, we call the peering healthy.
 func (t *Tracker) IsHealthy(s Status) bool {
+	// Defense in depth: if LastAck is recent (within heartbeat timeout),
+	// the stream is actively processing messages and is healthy regardless
+	// of the Connected state. This protects against stale disconnect calls
+	// that may have corrupted the Connected/DisconnectTime fields.
+	if s.LastAck != nil && t.timeNow().Sub(*s.LastAck) <= t.heartbeatTimeout {
+		return true
+	}
+
 	// If stream is in a disconnected state for longer than the configured
 	// heartbeat timeout, report as unhealthy.
 	if s.DisconnectTime != nil &&
@@ -329,6 +341,10 @@ type MutableStatus struct {
 	// doneCh allows for shutting down a stream gracefully by sending a termination message
 	// to the peer before the stream's context is cancelled.
 	doneCh chan struct{}
+
+	// streamGeneration is incremented each time TrackConnected is called.
+	// It is used to prevent stale stream goroutines from corrupting a newer stream's status.
+	streamGeneration uint64
 
 	Status
 }
@@ -475,13 +491,18 @@ func (s *Status) String() string {
 }
 
 func newMutableStatus(now func() time.Time, connected bool) *MutableStatus {
+	var gen uint64
+	if connected {
+		gen = 1
+	}
 	return &MutableStatus{
 		Status: Status{
 			Connected:      connected,
 			NeverConnected: !connected,
 		},
-		timeNow: now,
-		doneCh:  make(chan struct{}),
+		timeNow:          now,
+		doneCh:           make(chan struct{}),
+		streamGeneration: gen,
 	}
 }
 
@@ -536,12 +557,16 @@ func (s *MutableStatus) TrackNack(msg string) {
 	s.mu.Unlock()
 }
 
-func (s *MutableStatus) TrackConnected() {
+func (s *MutableStatus) TrackConnected() uint64 {
 	s.mu.Lock()
+	s.streamGeneration++
 	s.Connected = true
-	s.DisconnectTime = &time.Time{}
+	s.NeverConnected = false
+	s.DisconnectTime = nil
 	s.DisconnectErrorMessage = ""
+	gen := s.streamGeneration
 	s.mu.Unlock()
+	return gen
 }
 
 // TrackDisconnectedGracefully tracks when the stream was disconnected in a way we expected.
@@ -573,6 +598,34 @@ func (s *MutableStatus) TrackDisconnectedDueToError(error string) {
 			close(s.doneCh)
 		}
 	}
+}
+
+// TrackDisconnectedGracefullyIfCurrent only applies the graceful disconnect if the
+// given generation matches the current stream generation. Returns true if applied.
+func (s *MutableStatus) TrackDisconnectedGracefullyIfCurrent(gen uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.streamGeneration != gen {
+		return false
+	}
+	s.Connected = false
+	s.DisconnectTime = ptr(s.timeNow().UTC())
+	s.DisconnectErrorMessage = ""
+	return true
+}
+
+// TrackDisconnectedDueToErrorIfCurrent only applies the error disconnect if the
+// given generation matches the current stream generation. Returns true if applied.
+func (s *MutableStatus) TrackDisconnectedDueToErrorIfCurrent(gen uint64, error string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.streamGeneration != gen {
+		return false
+	}
+	s.Connected = false
+	s.DisconnectTime = ptr(s.timeNow().UTC())
+	s.DisconnectErrorMessage = error
+	return true
 }
 
 func (s *MutableStatus) IsConnected() bool {

--- a/agent/grpc-external/services/peerstream/stream_tracker_race_test.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker_race_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package peerstream
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleStream_DuplicateConnectionDoesNotCorruptStatus tests that when a second
+// stream tries to connect for the same peer ID while an active stream exists,
+// the active stream's status is NOT corrupted.
+//
+// This is a regression test for INFRA-14028 where HandleStream unconditionally
+// called DisconnectedDueToError even when Connected() failed, which corrupted
+// the active stream's status causing consul_peering_healthy to incorrectly
+// report unhealthy peerings.
+func TestHandleStream_DuplicateConnectionDoesNotCorruptStatus(t *testing.T) {
+	// Disable ConnectEnabled to skip trust domain checks which would require CA setup
+	srv, _ := newTestServer(t, func(c *Config) {
+		c.ConnectEnabled = false
+	})
+	peerID := "63b60245-c475-426b-b314-4588d210859d"
+
+	// Create context for Stream A that we can cancel to clean up
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+
+	// Create Stream A
+	streamA := newTestReplicationStream(ctxA)
+
+	// Track when Stream A has connected
+	streamAConnected := make(chan struct{})
+	streamADone := make(chan error, 1)
+
+	// Start Stream A in a goroutine - it will connect and then wait for messages
+	go func() {
+		// Signal when we've started (Connected() should be called very quickly)
+		go func() {
+			// Give a small window for Connected() to be called
+			time.Sleep(50 * time.Millisecond)
+			close(streamAConnected)
+		}()
+
+		err := srv.HandleStream(HandleStreamRequest{
+			LocalID:  peerID,
+			RemoteID: "remote-peer-id",
+			PeerName: "my-peer",
+			Stream:   streamA,
+		})
+		streamADone <- err
+	}()
+
+	// Wait for Stream A to connect
+	<-streamAConnected
+
+	// Verify Stream A is connected
+	status, ok := srv.Tracker.StreamStatus(peerID)
+	require.True(t, ok, "Stream A should have registered with tracker")
+	require.True(t, status.Connected, "Stream A should be connected")
+	require.Nil(t, status.DisconnectTime, "Stream A should have no DisconnectTime")
+
+	// Create context for Stream B
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	// Create Stream B with the same peer ID
+	streamB := newTestReplicationStream(ctxB)
+
+	// Stream B tries to connect - this should fail because Stream A is active
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var streamBErr error
+	go func() {
+		defer wg.Done()
+		streamBErr = srv.HandleStream(HandleStreamRequest{
+			LocalID:  peerID, // Same peer ID as Stream A
+			RemoteID: "remote-peer-id-2",
+			PeerName: "my-peer",
+			Stream:   streamB,
+		})
+	}()
+
+	// Wait for Stream B to finish (it should fail quickly at Connected())
+	wg.Wait()
+
+	// Stream B should have failed
+	require.Error(t, streamBErr, "Stream B should have failed to connect")
+	require.Contains(t, streamBErr.Error(), "there is an active stream",
+		"Stream B should fail because Stream A is already active")
+
+	// CRITICAL: Verify Stream A's status was NOT corrupted by Stream B's failed attempt
+	status, ok = srv.Tracker.StreamStatus(peerID)
+	require.True(t, ok, "Stream A should still be in tracker")
+	require.True(t, status.Connected,
+		"BUG: Stream A's Connected status was corrupted by Stream B's failed connection attempt")
+	require.Nil(t, status.DisconnectTime,
+		"BUG: Stream A's DisconnectTime was set by Stream B even though Stream A is still active")
+
+	// Clean up: close Stream A's receive channel to simulate client disconnect
+	// This causes Recv() to return io.EOF which terminates the stream handler
+	close(streamA.recvCh)
+	cancelA()
+
+	// Wait for Stream A to finish
+	select {
+	case <-streamADone:
+		// Stream A finished
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream A did not finish after context cancellation")
+	}
+}
+
+// TestHandleStream_NormalDisconnectUpdatesStatus verifies that when a stream
+// disconnects normally (not due to a duplicate connection), the status IS updated.
+// This ensures the fix doesn't break normal disconnect handling.
+func TestHandleStream_NormalDisconnectUpdatesStatus(t *testing.T) {
+	// Disable ConnectEnabled to skip trust domain checks which would require CA setup
+	srv, _ := newTestServer(t, func(c *Config) {
+		c.ConnectEnabled = false
+	})
+	peerID := "63b60245-c475-426b-b314-4588d210859d"
+
+	// Create context that we'll cancel to simulate disconnect
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stream := newTestReplicationStream(ctx)
+
+	streamDone := make(chan error, 1)
+
+	go func() {
+		err := srv.HandleStream(HandleStreamRequest{
+			LocalID:  peerID,
+			RemoteID: "remote-peer-id",
+			PeerName: "my-peer",
+			Stream:   stream,
+		})
+		streamDone <- err
+	}()
+
+	// Wait for stream to connect
+	require.Eventually(t, func() bool {
+		status, ok := srv.Tracker.StreamStatus(peerID)
+		return ok && status.Connected
+	}, 5*time.Second, 10*time.Millisecond, "Stream should connect")
+
+	// Close the receive channel to simulate client disconnect
+	// This causes Recv() to return io.EOF which terminates the stream handler
+	close(stream.recvCh)
+	cancel()
+
+	// Wait for HandleStream to return
+	select {
+	case <-streamDone:
+		// Stream finished
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not finish after context cancellation")
+	}
+
+	// After a normal disconnect, the status SHOULD be updated to disconnected
+	status, ok := srv.Tracker.StreamStatus(peerID)
+	require.True(t, ok, "Peer should still be in tracker")
+	require.False(t, status.Connected, "Stream should be marked as disconnected after normal disconnect")
+}
+
+// TestTracker_ConnectedFailsForDuplicatePeerID is a unit test that verifies
+// the Tracker.Connected() method correctly rejects duplicate peer IDs.
+func TestTracker_ConnectedFailsForDuplicatePeerID(t *testing.T) {
+	tracker := NewTracker(defaultIncomingHeartbeatTimeout)
+	peerID := "63b60245-c475-426b-b314-4588d210859d"
+
+	// First connection succeeds
+	status, _, err := tracker.Connected(peerID)
+	require.NoError(t, err)
+	require.True(t, status.Connected)
+
+	// Second connection with same peer ID fails
+	_, _, err = tracker.Connected(peerID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "there is an active stream for the given PeerID")
+
+	// Original status should be unchanged
+	streamStatus, ok := tracker.StreamStatus(peerID)
+	require.True(t, ok)
+	require.True(t, streamStatus.Connected)
+	require.Nil(t, streamStatus.DisconnectTime)
+}
+
+// TestHandleStream_StaleDisconnectDoesNotCorruptNewStream tests that when a stale
+// stream goroutine's disconnect fires after a new stream has connected, the new
+// stream's status is not corrupted.
+func TestHandleStream_StaleDisconnectDoesNotCorruptNewStream(t *testing.T) {
+	srv, _ := newTestServer(t, func(c *Config) {
+		c.ConnectEnabled = false
+	})
+	peerID := "63b60245-c475-426b-b314-4588d210859d"
+
+	// Simulate: Stream A connects (gen=1), then disconnects
+	ctxA, cancelA := context.WithCancel(context.Background())
+	streamA := newTestReplicationStream(ctxA)
+
+	streamADone := make(chan error, 1)
+	go func() {
+		streamADone <- srv.HandleStream(HandleStreamRequest{
+			LocalID:  peerID,
+			RemoteID: "remote-a",
+			PeerName: "my-peer",
+			Stream:   streamA,
+		})
+	}()
+
+	// Wait for Stream A to connect
+	require.Eventually(t, func() bool {
+		status, ok := srv.Tracker.StreamStatus(peerID)
+		return ok && status.Connected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Disconnect Stream A
+	close(streamA.recvCh)
+	cancelA()
+	select {
+	case <-streamADone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream A did not finish")
+	}
+
+	// Verify Stream A is disconnected
+	status, ok := srv.Tracker.StreamStatus(peerID)
+	require.True(t, ok)
+	require.False(t, status.Connected)
+
+	// Now Stream B connects (gen=2)
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	streamB := newTestReplicationStream(ctxB)
+
+	streamBDone := make(chan error, 1)
+	go func() {
+		streamBDone <- srv.HandleStream(HandleStreamRequest{
+			LocalID:  peerID,
+			RemoteID: "remote-b",
+			PeerName: "my-peer",
+			Stream:   streamB,
+		})
+	}()
+
+	// Wait for Stream B to connect
+	require.Eventually(t, func() bool {
+		status, ok := srv.Tracker.StreamStatus(peerID)
+		return ok && status.Connected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Simulate stale disconnect from Stream A's generation (gen=1)
+	// This should be a no-op because Stream B has gen=2
+	srv.Tracker.DisconnectedDueToError(peerID, 1, "stale error from old stream")
+
+	// Verify Stream B is still connected
+	status, ok = srv.Tracker.StreamStatus(peerID)
+	require.True(t, ok)
+	require.True(t, status.Connected,
+		"BUG: stale disconnect from old stream corrupted new stream's status")
+	require.Nil(t, status.DisconnectTime,
+		"BUG: stale disconnect set DisconnectTime on new stream")
+
+	// Clean up
+	close(streamB.recvCh)
+	cancelB()
+	select {
+	case <-streamBDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream B did not finish")
+	}
+}

--- a/agent/grpc-external/services/peerstream/stream_tracker_test.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker_test.go
@@ -101,7 +101,7 @@ func TestTracker_IsHealthy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := tc.tracker
 
-			st, err := tracker.Connected(aPeerID)
+			st, _, err := tracker.Connected(aPeerID)
 			require.NoError(t, err)
 			require.True(t, st.Connected)
 
@@ -128,8 +128,9 @@ func TestTracker_EnsureConnectedDisconnected(t *testing.T) {
 		err       error
 	)
 
+	var gen uint64
 	testutil.RunStep(t, "new stream", func(t *testing.T) {
-		statusPtr, err = tracker.Connected(peerID)
+		statusPtr, gen, err = tracker.Connected(peerID)
 		require.NoError(t, err)
 
 		expect := Status{
@@ -142,7 +143,7 @@ func TestTracker_EnsureConnectedDisconnected(t *testing.T) {
 	})
 
 	testutil.RunStep(t, "duplicate gets rejected", func(t *testing.T) {
-		_, err := tracker.Connected(peerID)
+		_, _, err := tracker.Connected(peerID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `there is an active stream for the given PeerID "63b60245-c475-426b-b314-4588d210859d"`)
 	})
@@ -166,7 +167,7 @@ func TestTracker_EnsureConnectedDisconnected(t *testing.T) {
 	})
 
 	testutil.RunStep(t, "disconnect", func(t *testing.T) {
-		tracker.DisconnectedGracefully(peerID)
+		tracker.DisconnectedGracefully(peerID, gen)
 		sequence++
 
 		expect := Status{
@@ -180,13 +181,12 @@ func TestTracker_EnsureConnectedDisconnected(t *testing.T) {
 	})
 
 	testutil.RunStep(t, "re-connect", func(t *testing.T) {
-		_, err := tracker.Connected(peerID)
+		_, _, err := tracker.Connected(peerID)
 		require.NoError(t, err)
 
 		expect := Status{
-			Connected:      true,
-			LastAck:        lastSuccess,
-			DisconnectTime: &time.Time{},
+			Connected: true,
+			LastAck:   lastSuccess,
 			// DisconnectTime gets cleared on re-connect.
 		}
 
@@ -236,10 +236,10 @@ func TestTracker_connectedStreams(t *testing.T) {
 		{
 			name: "all streams active",
 			setup: func(t *testing.T, s *Tracker) {
-				_, err := s.Connected("foo")
+				_, _, err := s.Connected("foo")
 				require.NoError(t, err)
 
-				_, err = s.Connected("bar")
+				_, _, err = s.Connected("bar")
 				require.NoError(t, err)
 			},
 			expect: []string{"bar", "foo"},
@@ -247,13 +247,13 @@ func TestTracker_connectedStreams(t *testing.T) {
 		{
 			name: "mixed active and inactive",
 			setup: func(t *testing.T, s *Tracker) {
-				status, err := s.Connected("foo")
+				status, _, err := s.Connected("foo")
 				require.NoError(t, err)
 
 				// Mark foo as disconnected to avoid showing it as an active stream
 				status.TrackDisconnectedGracefully()
 
-				_, err = s.Connected("bar")
+				_, _, err = s.Connected("bar")
 				require.NoError(t, err)
 			},
 			expect: []string{"bar"},
@@ -275,12 +275,13 @@ func TestMutableStatus_TrackConnected(t *testing.T) {
 			DisconnectErrorMessage: "disconnected",
 		},
 	}
-	s.TrackConnected()
+	gen := s.TrackConnected()
 
 	require.True(t, s.IsConnected())
 	require.True(t, s.Connected)
-	require.Equal(t, &time.Time{}, s.DisconnectTime)
+	require.Nil(t, s.DisconnectTime)
 	require.Empty(t, s.DisconnectErrorMessage)
+	require.Equal(t, uint64(1), gen)
 }
 
 func TestMutableStatus_TrackDisconnectedGracefully(t *testing.T) {


### PR DESCRIPTION
## Cherry-pick INFRA-14028 peering race condition fix

Cherry-pick and adapt the peering stream race condition fix from the `1.22-fix` branch to `1.15.4-hack-es`. This enables building `1.15.4-hack-es-8` with the fix.

### Problem
During simultaneous server restarts, a race condition in peering stream handling caused stream corruption:
1. **Duplicate connection corruption**: When a second stream connected for the same peer while an active stream existed, `Connected()` returned an error but `HandleStream` still called `DisconnectedDueToError()`, corrupting the active stream's status
2. **Stale disconnect corruption**: A stale `HandleStream` goroutine could overwrite a newer stream's `Connected=true` state when it finally disconnected

This caused `consul_peering_healthy` to incorrectly report unhealthy peerings even when they were actively communicating.

### Fix
- **Generation counter**: `MutableStatus` now tracks a `streamGeneration` that increments on each `TrackConnected()`. Disconnect methods check the generation to ensure only the current stream can mark the peer as disconnected.
- **Connected-aware error handling**: `realHandleStream` now returns `(generation, connected, error)` so `HandleStream` only marks the stream as disconnected when it was actually the connected stream.
- **IsHealthy defense-in-depth**: If `LastAck` is recent (within heartbeat timeout), the peering is considered healthy regardless of the `Connected` state, protecting against any stale disconnect that slips through.

### Changes
- `stream_tracker.go`: Generation counter, generation-aware `Connected()`/`DisconnectedGracefully()`/`DisconnectedDueToError()`, new `TrackDisconnectedGracefullyIfCurrent`/`TrackDisconnectedDueToErrorIfCurrent` methods, `IsHealthy` ACK timestamp check
- `stream_resources.go`: `realHandleStream` returns `(uint64, bool, error)`, `HandleStream` only disconnects when actually connected
- `stream_tracker_race_test.go`: Regression tests for duplicate connection and stale disconnect scenarios
- Updated test files for new API signatures

### Source Commits (from `1.22-fix`)
- `9e455b2304` — generation counter for MutableStatus (Connected returns bool+error, prevents stale DisconnectedDueToError)
- `967bf08844` — enhanced IsHealthy with ACK timestamp defense-in-depth

**Jira:** INFRA-14028