### PR TITLE
fix: keep peerstream send errors fatal

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -413,14 +413,19 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 
 	// streamSend is a helper function that queues msg to be sent over the stream.
 	// It accepts a context to allow the caller to control cancellation/timeout (e.g. heartbeat timeout).
+	// Send errors are only consumed by the main loop, which must own stream teardown.
 	streamSend := func(ctx context.Context, msg *pbpeerstream.ReplicationMessage) error {
+		if err := handleStreamCtx.Err(); err != nil {
+			return err
+		}
+
 		select {
 		case sendCh <- msg:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
-		case err := <-sendErrCh:
-			return err
+		case <-handleStreamCtx.Done():
+			return handleStreamCtx.Err()
 		}
 	}
 

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -6,6 +6,7 @@ package peerstream
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -825,6 +826,67 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			require.True(r, ok)
 			require.Equal(r, expect, status)
 		})
+	})
+}
+
+func TestStreamResources_Server_SendErrorFromAckDisconnectsStream(t *testing.T) {
+	it := incrementalTime{
+		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	srv, store := newTestServer(t, nil)
+	srv.Tracker.setClock(it.Now)
+
+	p := writePeeringToBeDialed(t, store, 1, "my-peer")
+	require.Empty(t, p.PeerID, "should be empty if being dialed")
+
+	// Set the initial roots and CA configuration.
+	_, _ = writeInitialRootsAndCA(t, store)
+
+	client := makeClient(t, srv, testPeerID)
+	client.DrainStream(t)
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := srv.StreamStatus(testPeerID)
+		require.True(r, ok)
+		require.True(r, status.Connected)
+	})
+
+	// Simulate the gRPC transport closing while the server is trying to ACK a
+	// resource response from the peer. This used to be swallowed by the ACK
+	// goroutine, leaving the old stream marked connected forever. New stream
+	// attempts then failed with "there is an active stream for the given PeerID",
+	// and the old stream's submatview materializers kept piling up.
+	transportErr := errors.New("transport is closing")
+	client.ReplicationStream.SetSendErr(transportErr)
+
+	resp := &pbpeerstream.ReplicationMessage{
+		Payload: &pbpeerstream.ReplicationMessage_Response_{
+			Response: &pbpeerstream.ReplicationMessage_Response{
+				ResourceURL: pbpeerstream.TypeURLExportedService,
+				ResourceID:  "api",
+				Nonce:       "21",
+				Operation:   pbpeerstream.Operation_OPERATION_UPSERT,
+				Resource:    makeAnyPB(t, &pbpeerstream.ExportedService{}),
+			},
+		},
+	}
+	require.NoError(t, client.Send(resp))
+
+	select {
+	case err := <-client.ErrCh:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error sending to stream: transport is closing")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream handler to return send error")
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := srv.StreamStatus(testPeerID)
+		require.True(r, ok)
+		require.False(r, status.Connected)
+		require.NotNil(r, status.DisconnectTime)
+		require.Equal(r, "error sending to stream: transport is closing", status.DisconnectErrorMessage)
 	})
 }
 

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -77,6 +77,9 @@ type MockStream struct {
 	sendCh chan *pbpeerstream.ReplicationMessage
 	recvCh chan *pbpeerstream.ReplicationMessage
 
+	mu      sync.Mutex
+	sendErr error
+
 	ctx context.Context
 }
 
@@ -92,8 +95,20 @@ func newTestReplicationStream(ctx context.Context) *MockStream {
 
 // Send implements pbpeerstream.PeeringService_StreamResourcesServer
 func (s *MockStream) Send(r *pbpeerstream.ReplicationMessage) error {
+	s.mu.Lock()
+	err := s.sendErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
 	s.sendCh <- r
 	return nil
+}
+
+func (s *MockStream) SetSendErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendErr = err
 }
 
 // Recv implements pbpeerstream.PeeringService_StreamResourcesServer


### PR DESCRIPTION
## Summary
- keep peerstream `Stream.Send` errors fatal to `realHandleStream`
- prevent non-owner `streamSend` callers (heartbeat / ACK-NACK goroutines) from consuming `sendErrCh`
- preserve the async send queue, but make queued sends also unblock when the stream handler is cancelled
- add regression coverage for a transport close while sending an ACK for an inbound resource response

## Why
The async send queue was added to keep the main loop reading from `recvCh` even when sending is slow/full, avoiding peerstream deadlocks.

The bug was error ownership: `sendErrCh` was read both by the main stream loop and by helper callers of `streamSend`. If an ACK/heartbeat goroutine consumed the fatal send error, the main handler could stay alive and leave the peer marked connected. New stream attempts then hit `there is an active stream for the given PeerID`, while the old stream's subscription/materializer work could remain around.

This keeps the async queue, but makes the main loop the only owner of send errors and stream teardown. `streamSend` still honors caller timeouts, and now also returns promptly if the overall stream handler has been cancelled.

## Verification
- `go test ./agent/grpc-external/services/peerstream -run 'TestStreamResources_Server_SendErrorFromAckDisconnectsStream|TestStreamResources_Server_StreamTracker' -count=1`
- `go test ./agent/grpc-external/services/peerstream -count=1`
- `git diff --check`
