### PR TITLE
fix: cancel peerstream subscriptions with handler context

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -413,14 +413,19 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 
 	// streamSend is a helper function that queues msg to be sent over the stream.
 	// It accepts a context to allow the caller to control cancellation/timeout (e.g. heartbeat timeout).
+	// Send errors are only consumed by the main loop, which must own stream teardown.
 	streamSend := func(ctx context.Context, msg *pbpeerstream.ReplicationMessage) error {
+		if err := handleStreamCtx.Err(); err != nil {
+			return err
+		}
+
 		select {
 		case sendCh <- msg:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
-		case err := <-sendErrCh:
-			return err
+		case <-handleStreamCtx.Done():
+			return handleStreamCtx.Err()
 		}
 	}
 

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -356,7 +356,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 
 	remoteSubTracker := newResourceSubscriptionTracker()
 	mgr := newSubscriptionManager(
-		streamReq.Stream.Context(),
+		handleStreamCtx,
 		logger,
 		s.Config,
 		trustDomain,
@@ -364,7 +364,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) (uint64, bool, 
 		s.GetStore,
 		remoteSubTracker,
 	)
-	subCh := mgr.subscribe(streamReq.Stream.Context(), streamReq.LocalID, streamReq.PeerName, streamReq.Partition)
+	subCh := mgr.subscribe(handleStreamCtx, streamReq.LocalID, streamReq.PeerName, streamReq.Partition)
 
 	// sendCh is used to queue messages to be sent to the stream.
 	// We buffer this to prevent the main loop from blocking on sends, which could lead to deadlocks

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -6,6 +6,7 @@ package peerstream
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -825,6 +826,67 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			require.True(r, ok)
 			require.Equal(r, expect, status)
 		})
+	})
+}
+
+func TestStreamResources_Server_SendErrorFromAckDisconnectsStream(t *testing.T) {
+	it := incrementalTime{
+		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	srv, store := newTestServer(t, nil)
+	srv.Tracker.setClock(it.Now)
+
+	p := writePeeringToBeDialed(t, store, 1, "my-peer")
+	require.Empty(t, p.PeerID, "should be empty if being dialed")
+
+	// Set the initial roots and CA configuration.
+	_, _ = writeInitialRootsAndCA(t, store)
+
+	client := makeClient(t, srv, testPeerID)
+	client.DrainStream(t)
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := srv.StreamStatus(testPeerID)
+		require.True(r, ok)
+		require.True(r, status.Connected)
+	})
+
+	// Simulate the gRPC transport closing while the server is trying to ACK a
+	// resource response from the peer. This used to be swallowed by the ACK
+	// goroutine, leaving the old stream marked connected forever. New stream
+	// attempts then failed with "there is an active stream for the given PeerID",
+	// and the old stream's submatview materializers kept piling up.
+	transportErr := errors.New("transport is closing")
+	client.ReplicationStream.SetSendErr(transportErr)
+
+	resp := &pbpeerstream.ReplicationMessage{
+		Payload: &pbpeerstream.ReplicationMessage_Response_{
+			Response: &pbpeerstream.ReplicationMessage_Response{
+				ResourceURL: pbpeerstream.TypeURLExportedService,
+				ResourceID:  "api",
+				Nonce:       "21",
+				Operation:   pbpeerstream.Operation_OPERATION_UPSERT,
+				Resource:    makeAnyPB(t, &pbpeerstream.ExportedService{}),
+			},
+		},
+	}
+	require.NoError(t, client.Send(resp))
+
+	select {
+	case err := <-client.ErrCh:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error sending to stream: transport is closing")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream handler to return send error")
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		status, ok := srv.StreamStatus(testPeerID)
+		require.True(r, ok)
+		require.False(r, status.Connected)
+		require.NotNil(r, status.DisconnectTime)
+		require.Equal(r, "error sending to stream: transport is closing", status.DisconnectErrorMessage)
 	})
 }
 

--- a/agent/grpc-external/services/peerstream/testing.go
+++ b/agent/grpc-external/services/peerstream/testing.go
@@ -77,6 +77,9 @@ type MockStream struct {
 	sendCh chan *pbpeerstream.ReplicationMessage
 	recvCh chan *pbpeerstream.ReplicationMessage
 
+	mu      sync.Mutex
+	sendErr error
+
 	ctx context.Context
 }
 
@@ -92,8 +95,20 @@ func newTestReplicationStream(ctx context.Context) *MockStream {
 
 // Send implements pbpeerstream.PeeringService_StreamResourcesServer
 func (s *MockStream) Send(r *pbpeerstream.ReplicationMessage) error {
+	s.mu.Lock()
+	err := s.sendErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
 	s.sendCh <- r
 	return nil
+}
+
+func (s *MockStream) SetSendErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendErr = err
 }
 
 // Recv implements pbpeerstream.PeeringService_StreamResourcesServer


### PR DESCRIPTION
## Summary
- tie peerstream subscription manager and subscription watch to `handleStreamCtx`
- ensures stream-local subscriptions are canceled when the handler exits on send/recv/heartbeat errors
- targets reconnect churn where old stream resources can survive briefly and collide with a new stream (`active stream for PeerID`)

## Verification
- `go test ./agent/grpc-external/services/peerstream -run 'TestStreamResources_Server_SendErrorFromAckDisconnectsStream|TestStreamResources_Server_ServiceUpdates|TestMutableStatus' -count=1`
- built downstream image locally as `registry.internal.telnyx.com/infra/consul:1.22.1-v9`
- smoke-tested local dev agent: `/v1/status/leader` returned `"127.0.0.1:8300"`

## Notes
- observed live failure on `dx1-ora` leader pod: peerstream send errors plus `failed to register stream: there is an active stream for the given PeerID`
- current live image remains `1.22.1-v7`; this PR is source fix only
