### PR TITLE
fix: stop peerstream materialized views on stream close

### DIFF
--- a/agent/grpc-external/services/peerstream/subscription_manager.go
+++ b/agent/grpc-external/services/peerstream/subscription_manager.go
@@ -68,6 +68,10 @@ func newSubscriptionManager(
 	logger = logger.Named("subscriptions")
 	store := submatview.NewStore(logger.Named("viewstore"))
 	go store.Run(ctx)
+	go func() {
+		<-ctx.Done()
+		store.Stop()
+	}()
 
 	return &subscriptionManager{
 		logger:               logger,

--- a/agent/submatview/store.go
+++ b/agent/submatview/store.go
@@ -105,6 +105,23 @@ func (s *Store) Run(ctx context.Context) {
 	}
 }
 
+func (s *Store) Stop() {
+	s.stopAll()
+}
+
+func (s *Store) stopAll() {
+	s.lock.Lock()
+	entries := s.byKey
+	s.byKey = make(map[string]entry)
+	s.expiryHeap = ttlcache.NewExpiryHeap()
+	s.lock.Unlock()
+
+	for key, e := range entries {
+		s.logger.Trace("stopping item from store shutdown", "key", key)
+		e.stop()
+	}
+}
+
 // Request is used to request data from the Store.
 // Note that cache.Request is required, but some of the fields cache.RequestInfo
 // fields are ignored (ex: MaxAge, and MustRevalidate).
@@ -281,7 +298,10 @@ func (s *Store) evictNow(key string) {
 func (s *Store) releaseEntry(key string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	e := s.byKey[key]
+	e, ok := s.byKey[key]
+	if !ok {
+		return
+	}
 	e.requests--
 	s.byKey[key] = e
 

--- a/agent/submatview/store_test.go
+++ b/agent/submatview/store_test.go
@@ -203,6 +203,70 @@ type resultOrError struct {
 	Err    error
 }
 
+func TestStore_StopStopsMaterializers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := NewStore(hclog.New(nil))
+	go store.Run(ctx)
+
+	mat := &blockingMaterializer{
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	req := &blockingRequest{mat: mat, timeout: 10 * time.Millisecond}
+
+	_, err := store.Get(context.Background(), req)
+	require.NoError(t, err)
+
+	select {
+	case <-mat.started:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected materializer to start")
+	}
+
+	store.Stop()
+
+	select {
+	case <-mat.stopped:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected Store.Stop to stop materializer")
+	}
+}
+
+type blockingRequest struct {
+	mat     Materializer
+	timeout time.Duration
+}
+
+func (r *blockingRequest) CacheInfo() cache.RequestInfo {
+	return cache.RequestInfo{
+		Key:        "key",
+		Token:      "abcd",
+		Datacenter: "dc1",
+		Timeout:    r.timeout,
+	}
+}
+
+func (r *blockingRequest) NewMaterializer() (Materializer, error) { return r.mat, nil }
+func (r *blockingRequest) Type() string                           { return fmt.Sprintf("%T", r) }
+
+type blockingMaterializer struct {
+	started chan struct{}
+	stopped chan struct{}
+}
+
+func (m *blockingMaterializer) Run(ctx context.Context) {
+	close(m.started)
+	<-ctx.Done()
+	close(m.stopped)
+}
+
+func (m *blockingMaterializer) Query(ctx context.Context, minIndex uint64) (Result, error) {
+	<-ctx.Done()
+	return Result{}, ctx.Err()
+}
+
 type fakeRPCRequest struct {
 	index   uint64
 	timeout time.Duration


### PR DESCRIPTION
## Summary
- Stop each peerstream subscription manager's submatview Store when the stream context closes.
- Add Store.Stop to cancel all active materializers immediately instead of waiting for idle TTL expiry after the store run loop is gone.
- Make releaseEntry tolerate Store.Stop racing with request cleanup.

## Why
Live dx1-ora pprof/logs showed the leak is not primarily the duplicate active-stream error. The real accumulation is per-stream submatview materializers left running after stream teardown:
- ~9.5k goroutines in `grpc-internal/services/subscribe.Subscribe -> stream.Subscription.Next`
- ~8.5k goroutines in `submatview.RPCMaterializer.subscribeOnce/Run`
- ~2.9k goroutines in `submatview.LocalMaterializer.subscribeOnce/Run`

`newSubscriptionManager` creates one `submatview.Store` per peerstream. When the stream context is canceled, `Store.Run(ctx)` exits, but existing entries/materializers are not stopped. Notify callbacks release entries and put them on the expiry heap, but the expiry loop is already gone, so materializers stay alive indefinitely.

The duplicate `failed to register stream: there is an active stream for the given PeerID` errors are a symptom/amplifier after churn; this fixes the materializer cleanup path that pprof proves is leaking goroutines.

## Verification
- `go test ./agent/submatview -count=1`
- `go test ./agent/grpc-external/services/peerstream -run 'TestSubscriptionManager' -count=1`
- Full peerstream package test was not usable locally: existing freeport failure (`freeport: block size too small`) before test bodies.
